### PR TITLE
fix: default option for select elements

### DIFF
--- a/src/components/form/Assertion.svelte
+++ b/src/components/form/Assertion.svelte
@@ -19,6 +19,7 @@
 <p>Comparison Method:</p>
 
 <select bind:value={isNot} on:change={() => updateVal()}>
+  <option>...</option>
   {#each nots as value}
     <option {value}>
       {value}
@@ -26,13 +27,14 @@
   {/each}
 </select>
 <select bind:value={selectedAssertion} on:change={() => updateVal()}>
+  <option>...</option>
   {#each assertions as value}
     <option {value}>
       {value}
     </option>
   {/each}
 </select>
-<label for={id}>Assertion: </label>
+<label for={id}>Assertion</label>
 <input
   name={id}
   type="text"

--- a/src/components/form/Expect.svelte
+++ b/src/components/form/Expect.svelte
@@ -11,20 +11,13 @@
   const queries = ["toContain", "toBe", "toBeTruthy"];
 </script>
 
-<p>expect...</p>
-<!-- <select bind:value={selectedQuery} on:change={() => updateVal()}>
-  {#each queries as value}
-    <option {value}>
-      {value}
-    </option>
-  {/each}
+<div>
+  <p>expect...</p>
+</div>
 
-</select>
- 
-<label for={id}>Argument: </label>
-<input
-  name={id}
-  type="text"
-  placeholder="ex. 'Hello World'"
-  bind:value={argument}
-  on:change={() => updateVal()} > -->
+<style>
+  div {
+    display: flex;
+    width: 100%;
+  }
+</style>

--- a/src/components/form/Mock.svelte
+++ b/src/components/form/Mock.svelte
@@ -11,6 +11,7 @@
     name="mockInput"
     bind:value={$blockStore[id]["value"]}
   >
+    <option>...</option>
     {#each options as option}
       <option value={option}>{option}</option>
     {/each}

--- a/src/components/form/MockStatement.svelte
+++ b/src/components/form/MockStatement.svelte
@@ -75,6 +75,7 @@
       bind:value={attribute}
       on:change={() => updateVal()}
     >
+      <option>...</option>
       {#each attributes as value}
         <option {value}>
           {value}

--- a/src/components/form/Query.svelte
+++ b/src/components/form/Query.svelte
@@ -37,6 +37,7 @@
     bind:value={selectedQuery}
     on:change={() => updateVal()}
   >
+    <option>...</option>
     {#each queries as value}
       <option {value}>
         {value}
@@ -53,6 +54,7 @@
     bind:value={selectedType}
     on:change={() => updateVal()}
   >
+    <option>...</option>
     {#each types as value}
       <option {value}>
         {value}

--- a/src/components/form/UserEvent.svelte
+++ b/src/components/form/UserEvent.svelte
@@ -21,6 +21,7 @@
 
 <p>Events</p>
 <select bind:value={event} on:change={() => updateVal()}>
+  <option>...</option>
   {#each events as value}
     <option {value}>
       {value}


### PR DESCRIPTION
Add a default option "..." for all select statements. This makes it more visually apparent that a real option needs to be selected.

Note: The code editor may still accept ... as an input. This is fine for our MVP, but we probably need a more robust solution that prevents invalid responses from being submitted.