### PR TITLE
fix: logo link

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -8,7 +8,7 @@
 
 <header>
   <!-- <h1>🦺 Sveste</h1> -->
-  <a href="/home">
+  <a href="#/home">
     <img src={logoUrl} alt="Sveste" />
     <h1>Sveste</h1>
   </a>


### PR DESCRIPTION
missing a '#' in the route for the spa-router