### PR TITLE
fixes: inputs and nav tree

### DIFF
--- a/src/components/NavBlock.svelte
+++ b/src/components/NavBlock.svelte
@@ -5,7 +5,7 @@
   import type { Block } from '../controllers/blockClass';
   import {} from 'os';
 
-  let isOpen = false;
+  let isOpen = true;
   const toggleMenu = () => {
     isOpen = !isOpen;
   };
@@ -39,10 +39,12 @@
   on:click|preventDefault={toggleMenu}
 >
   {#if /describe|root/i.test(name)}
-    {#if isOpen}
-      <ExpandLess />
-    {:else}
-      <ExpandMore />
+    {#if children.length}
+      {#if isOpen}
+        <ExpandLess />
+      {:else}
+        <ExpandMore />
+      {/if}
     {/if}
   {/if}
   {name.replace(/([a-z]*)(Statement|Block|)/g, '$1').toLowerCase()}

--- a/src/components/form/Input.svelte
+++ b/src/components/form/Input.svelte
@@ -6,7 +6,7 @@
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
   const labelText = capitalizeFirstLetter(inputType);
-  const idText = inputType + 'Input';
+  const idText = id + inputType + 'Input';
 </script>
 
 <input required id={idText} name={idText} bind:value={$blockStore[id].value} />


### PR DESCRIPTION
- Fixed issue caused by inputs with duplicate keys. Previously, clicking on an "nth" describe or test statement would navigate you to the 1st statement in the test.
- Set the nav tree to be open by default so it's more apparent that it exists.